### PR TITLE
add rootNode expansion node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gatewayapps/ims-react-components",
-  "version": "0.7.3",
+  "version": "0.7.4-test",
   "main": "./dist/index.js",
   "scripts": {
     "prepublishOnly": "yarn build",

--- a/src/TreeView/ITreeViewCommonProps.ts
+++ b/src/TreeView/ITreeViewCommonProps.ts
@@ -24,4 +24,8 @@ export interface ITreeViewCommonProps {
   shouldRenderNode?: (props: RenderNodeProps) => boolean
 }
 
-export type InitialExpansionModes = 'selectedNodeOnly' | 'selectedNodeAndCousins' | 'none'
+export type InitialExpansionModes =
+  | 'rootNode'
+  | 'selectedNodeOnly'
+  | 'selectedNodeAndCousins'
+  | 'none'

--- a/src/TreeView/TreeView.tsx
+++ b/src/TreeView/TreeView.tsx
@@ -4,7 +4,7 @@ import { TreeViewNode } from './TreeViewNode'
 
 import { ITreeViewProps } from './ITreeViewProps'
 import { INodeHashMapEntry } from './ITreeViewNodeProps'
-import { RenderNodeProps } from './ITreeViewCommonProps'
+import { InitialExpansionModes, RenderNodeProps } from './ITreeViewCommonProps'
 import { useFetch } from '../utils/useFetch'
 import { useDebounce } from 'react-use'
 
@@ -60,7 +60,8 @@ export const TreeView = (props: ITreeViewProps) => {
 
       populateNodeHashMap(response, hashMap)
       if (props.initialExpansionMode) {
-        applyInitialExpansion(props.initialExpansionMode, props.selectedNodeId, hashMap)
+        const rootNode = response.length > 0 ? response[0] : undefined
+        applyInitialExpansion(props.initialExpansionMode, props.selectedNodeId, hashMap, rootNode)
       }
 
       if (props.onTreeLoaded) {
@@ -118,9 +119,10 @@ export const TreeView = (props: ITreeViewProps) => {
 }
 
 const applyInitialExpansion = (
-  expansionMode: string,
+  expansionMode: InitialExpansionModes,
   selectedNodeId: number | undefined,
-  hashMap: { [key: number]: INodeHashMapEntry }
+  hashMap: { [key: number]: INodeHashMapEntry },
+  rootNode?: number
 ) => {
   if (selectedNodeId) {
     switch (expansionMode) {
@@ -146,6 +148,10 @@ const applyInitialExpansion = (
           parentId = hashMap[parentId].parent
         }
       }
+    }
+  } else {
+    if (expansionMode === 'rootNode' && rootNode) {
+      hashMap[rootNode].defaultExpanded = true
     }
   }
 }


### PR DESCRIPTION
- Add new `rootNode` expansion mode
- Use the `InitialExpansionModes` type in the code
- If there is no selected node id and the expansionMode is `rootNode`, then get the first node from the array response and set it's expand property to true